### PR TITLE
Switch Build Image to Standard 4

### DIFF
--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -142,7 +142,7 @@ Resources:
       EncryptionKey: !ImportValue cfn-utilities:ArtifactKeyArn
       Environment:
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         EnvironmentVariables:
           - Name: ARTIFACT_STORE


### PR DESCRIPTION
This switches the build image used to standard 4 so we can use nerdbank.gitversioning