### PR TITLE
BRGD-14 Keys Should Have Internal Setters

### DIFF
--- a/src/Server/Applications/Models/Application.cs
+++ b/src/Server/Applications/Models/Application.cs
@@ -14,7 +14,7 @@ namespace Brighid.Identity.Applications
         /// </summary>
         /// <value>A unique id number.</value>
         [Key]
-        public virtual Guid Id { get; set; } = Guid.NewGuid();
+        public virtual Guid Id { get; internal set; } = Guid.NewGuid();
 
         /// <summary>
         /// Gets the unique name for this application.

--- a/src/Server/Roles/Models/Role.cs
+++ b/src/Server/Roles/Models/Role.cs
@@ -13,7 +13,7 @@ namespace Brighid.Identity.Roles
         /// </summary>
         /// <value>A unique id number.</value>
         [Key]
-        public override Guid Id { get; set; } = Guid.NewGuid();
+        public new Guid Id { get; internal set; } = Guid.NewGuid();
 
         /// <summary>
         /// Gets or sets the description of the role.

--- a/src/Server/Users/Models/User.cs
+++ b/src/Server/Users/Models/User.cs
@@ -14,7 +14,7 @@ namespace Brighid.Identity.Users
     {
 
         [Key]
-        public override Guid Id { get; set; } = Guid.NewGuid();
+        public new Guid Id { get; internal set; } = Guid.NewGuid();
 
         [NotMapped]
         [JsonIgnore]

--- a/src/Server/Users/Models/UserClaim.cs
+++ b/src/Server/Users/Models/UserClaim.cs
@@ -9,7 +9,7 @@ namespace Brighid.Identity.Users
     public class UserClaim : IdentityUserClaim<Guid>
     {
         [Key]
-        public new Guid Id { get; set; } = Guid.NewGuid();
+        public new Guid Id { get; internal set; } = Guid.NewGuid();
 
         public override Guid UserId { get; set; }
 

--- a/src/Server/Users/Models/UserLogin.cs
+++ b/src/Server/Users/Models/UserLogin.cs
@@ -13,7 +13,7 @@ namespace Brighid.Identity.Users
     public class UserLogin : IdentityUserLogin<Guid>
     {
         [Key]
-        public Guid Id { get; private set; } = Guid.NewGuid();
+        public Guid Id { get; internal set; } = Guid.NewGuid();
 
         [JsonIgnore]
         public override Guid UserId { get; set; }

--- a/src/Server/Users/Models/UserLoginAttribute.cs
+++ b/src/Server/Users/Models/UserLoginAttribute.cs
@@ -9,7 +9,7 @@ namespace Brighid.Identity.Users
 
         public string Value { get; set; }
 
-        public Guid LoginId { get; set; }
+        public Guid LoginId { get; internal set; }
 
         [ForeignKey("LoginId")]
         public UserLogin Login { get; set; }


### PR DESCRIPTION
This makes setters for primary keys internal, so that users cannot override them in their request payloads.