### PR TITLE
Allow Custom Identity Server Uri

### DIFF
--- a/src/Client/ConfigurationContext.cs
+++ b/src/Client/ConfigurationContext.cs
@@ -1,8 +1,10 @@
+using System;
 namespace Brighid.Identity.Client
 {
     internal class ConfigurationContext
     {
         public string BaseAddress { get; set; } = "";
         public string ConfigSectionName { get; set; } = "";
+        public Uri IdentityServerUri { get; set; } = new Uri("https://identity.brigh.id/");
     }
 }

--- a/src/Client/IdentityOptionsBuilder.cs
+++ b/src/Client/IdentityOptionsBuilder.cs
@@ -18,6 +18,12 @@ namespace Brighid.Identity.Client
             context = new ConfigurationContext();
         }
 
+        public IdentityOptionsBuilder<TServiceType, TImplementation> WithIdentityServerUri(Uri identityServerUri)
+        {
+            context.IdentityServerUri = identityServerUri;
+            return this;
+        }
+
         public IdentityOptionsBuilder<TServiceType, TImplementation> WithBaseAddress(string baseAddress)
         {
             context.BaseAddress = baseAddress;

--- a/src/Client/IdentityServicesConfigurer.cs
+++ b/src/Client/IdentityServicesConfigurer.cs
@@ -30,7 +30,7 @@ namespace Brighid.Identity.Client
             services.TryAddScoped<ClientCredentialsHandler<TCredentials>>();
 
             services
-            .AddHttpClient<IdentityServerClient>(options => options.BaseAddress = new Uri("https://identity.brigh.id/"));
+            .AddHttpClient<IdentityServerClient>(options => options.BaseAddress = context.IdentityServerUri);
 
             var baseUri = new Uri(context.BaseAddress);
             services


### PR DESCRIPTION
This allows specifying a custom identity server URI in the client.  That way, clients may use the dev url if they wish.