### PR TITLE
BRGD-129 Signup 500 Error

### DIFF
--- a/src/Server/Auth/Abstractions/IdentityCookieAuthenticationEvents.cs
+++ b/src/Server/Auth/Abstractions/IdentityCookieAuthenticationEvents.cs
@@ -16,6 +16,7 @@ namespace Brighid.Identity.Auth
             OnRedirectToAccessDenied = OnRedirectToAccessDeniedHandler;
             OnRedirectToLogin = OnRedirectToLoginHandler;
             OnSigningIn = OnSigningInHandler;
+            OnSignedIn = OnSignedInHandler;
             cookieOptions = new CookieOptions { Domain = authConfig.CookieDomain };
         }
 
@@ -54,6 +55,16 @@ namespace Brighid.Identity.Auth
                          select authToken.Value).First();
 
             context.HttpContext.Response.Cookies.Append(".Brighid.IdentityToken", token, cookieOptions);
+            return Task.FromResult(0);
+        }
+
+        public Task OnSignedInHandler(CookieSignedInContext context)
+        {
+            if (context.Properties.RedirectUri != null)
+            {
+                context.Response.Redirect(context.Properties.RedirectUri);
+            }
+
             return Task.FromResult(0);
         }
     }

--- a/tests/Internal/TargetRelay.cs
+++ b/tests/Internal/TargetRelay.cs
@@ -6,6 +6,12 @@ using System.Reflection;
 using AutoFixture.AutoNSubstitute;
 using AutoFixture.Kernel;
 
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+using NSubstitute;
+
 public class TargetRelay : ISpecimenBuilder
 {
     public object Create(object request, ISpecimenContext context)
@@ -35,6 +41,15 @@ public class TargetRelay : ISpecimenBuilder
         var instance = parameters.Any()
             ? Activator.CreateInstance(type, parameters)
             : Activator.CreateInstance(type, true);
+
+        if (instance is Controller controller)
+        {
+            var tempDataProvider = Substitute.For<ITempDataProvider>();
+            var tempDataDictionaryFactory = new TempDataDictionaryFactory(tempDataProvider);
+            var tempData = tempDataDictionaryFactory.GetTempData(new DefaultHttpContext());
+
+            controller.TempData = tempData;
+        }
 
         return instance ?? new NoSpecimen();
     }


### PR DESCRIPTION
When password exchange was refactored to not use the built-in asp.net core identity method, the signup controller was not updated to use the new password exchange method as well.