### PR TITLE
Add CookieStore Polyfill

### DIFF
--- a/src/Server/Common/Pages/Shared/_Layout.cshtml
+++ b/src/Server/Common/Pages/Shared/_Layout.cshtml
@@ -17,10 +17,4 @@
 <body>
     @RenderBody()
 
-    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.17.0/jquery.validate.min.js"
-        integrity="sha384-rZfj/ogBloos6wzLGpPkkOr/gpkBNLZ6b6yLy4o+ok+t/SAKlL5mvXLr0OXNi1Hp">
-        </script>
-    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validation.unobtrusive/3.2.9/jquery.validate.unobtrusive.min.js"
-        crossorigin="anonymous" integrity="sha384-ifv0TYDWxBHzvAk2Z0n8R434FL1Rlv/Av18DXE43N/1rvHyOG4izKst0f2iSLdds">
-        </script>
 </body>

--- a/src/Server/Common/Pages/_Host.cshtml
+++ b/src/Server/Common/Pages/_Host.cshtml
@@ -14,4 +14,5 @@
     <a href="" class="reload">Reload</a>
     <a class="dismiss">🗙</a>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/cookie-store@3.0.0/index.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>


### PR DESCRIPTION
This adds a polyfill for the cookie store API (the browser storage blazor extension relies on this).  The service was not working on mobile iOS.