### PR TITLE
BRGD-200 Exit if Decryption Fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ "$Environment" != "local" ]; then
-    export Database__Password=$(decrs ${Encrypted__Database__Password});
+    export Database__Password=$(decrs ${Encrypted__Database__Password}) || exit 1;
     runuser --user brighid /app/Server
     exit $?
 fi


### PR DESCRIPTION
Adjusts the docker image's entrypoint to exit if decrypting a secret fails.