### PR TITLE
BRGD-187 Disable User Login Endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
   "omnisharp.enableRoslynAnalyzers": true,
   "editor.semanticHighlighting.enabled": true,
   "csharp.semanticHighlighting.enabled": true,
+  "omnisharp.enableImportCompletion": true,
   "yaml.customTags": [
     "!And",
     "!And sequence",

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Configuration Condition="$(Configuration) == ''">Debug</Configuration>
         <Nullable>enable</Nullable>
-        <LangVersion>10</LangVersion>
+        <LangVersion>preview</LangVersion>
         <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
         <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Common/Users/Converters/UserFlagsConverter.cs
+++ b/src/Common/Users/Converters/UserFlagsConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#pragma warning disable IDE0060
+
+namespace Brighid.Identity.Users
+{
+    public class UserFlagsConverter : JsonConverter<UserFlags>
+    {
+        public override UserFlags Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var number = reader.GetInt64();
+            return (UserFlags)number;
+        }
+
+        public override void Write(Utf8JsonWriter writer, UserFlags value, JsonSerializerOptions options)
+        {
+            writer.WriteNumberValue((long)value);
+        }
+    }
+}

--- a/src/Common/Users/Models/User.cs
+++ b/src/Common/Users/Models/User.cs
@@ -46,6 +46,7 @@ namespace Brighid.Identity.Users
         /// <summary>
         /// Gets or sets the user's flags in a bit-packed field.
         /// </summary>
+        [JsonConverter(typeof(UserFlagsConverter))]
         public UserFlags Flags { get; set; } = UserFlags.None;
 
         public virtual ICollection<UserLogin> Logins { get; set; } = new List<UserLogin>();

--- a/src/Server/Common/Abstractions/IErrorException.cs
+++ b/src/Server/Common/Abstractions/IErrorException.cs
@@ -1,0 +1,7 @@
+namespace Brighid.Identity
+{
+    public interface IErrorException
+    {
+        public object Error { get; }
+    }
+}

--- a/src/Server/Common/Abstractions/IExceptionMapping.cs
+++ b/src/Server/Common/Abstractions/IExceptionMapping.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Brighid.Identity
+{
+    public interface IExceptionMapping
+    {
+        public Type Exception { get; }
+
+        public int StatusCode { get; }
+    }
+}

--- a/src/Server/Common/Exceptions/ModelStateException.cs
+++ b/src/Server/Common/Exceptions/ModelStateException.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Brighid.Identity
 {
-    public class ModelStateException : Exception
+    public class ModelStateException : Exception, IErrorException
     {
         public ModelStateException(ModelStateDictionary modelState)
             : base("One or more errors occurred.")
@@ -19,5 +19,7 @@ namespace Brighid.Identity
         }
 
         public IEnumerable<string> Errors { get; }
+
+        public object Error => new { Message, Errors };
     }
 }

--- a/src/Server/Common/Filters/ExceptionMappingAttribute.cs
+++ b/src/Server/Common/Filters/ExceptionMappingAttribute.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Brighid.Identity
+{
+    public class ExceptionMappingAttribute<TException> : ActionFilterAttribute, IExceptionMapping
+        where TException : Exception
+    {
+        public ExceptionMappingAttribute(HttpStatusCode statusCode)
+        {
+            StatusCode = (int)statusCode;
+        }
+
+        public Type Exception => typeof(TException);
+
+        public int StatusCode { get; }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.Exception is TException exception)
+            {
+                var error = exception is IErrorException errorException
+                    ? errorException.Error
+                    : new { exception.Message };
+
+                context.ExceptionHandled = true;
+                context.Result = new ObjectResult(error)
+                {
+                    StatusCode = StatusCode,
+                };
+            }
+        }
+    }
+}

--- a/src/Server/Users/Controllers/UserController.cs
+++ b/src/Server/Users/Controllers/UserController.cs
@@ -39,7 +39,7 @@ namespace Brighid.Identity.Users
             return Ok(result);
         }
 
-        [HttpPatch("{userId}/debug-mode", Name = "Users:SetDebugMode")]
+        [HttpPut("{userId}/debug-mode", Name = "Users:SetDebugMode")]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
         [ExceptionMapping<UserNotFoundException>(HttpStatusCode.NotFound)]
         [ExceptionMapping<SecurityException>(HttpStatusCode.Forbidden)]

--- a/src/Server/Users/Controllers/UserController.cs
+++ b/src/Server/Users/Controllers/UserController.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Net;
+using System.Security;
 using System.Threading.Tasks;
 
 using Brighid.Identity.Roles;
 
 using Microsoft.AspNetCore.Mvc;
-
-#pragma warning disable IDE0050
 
 namespace Brighid.Identity.Users
 {
@@ -31,15 +30,10 @@ namespace Brighid.Identity.Users
         }
 
         [HttpGet("{userId}")]
+        [ExceptionMapping<UserNotFoundException>(HttpStatusCode.NotFound)]
         public async Task<ActionResult<User>> Get(Guid userId)
         {
-            var result = await repository.FindById(userId);
-
-            if (result == null)
-            {
-                return NotFound();
-            }
-
+            var result = await repository.FindById(userId) ?? throw new UserNotFoundException(userId);
             await repository.LoadCollection(result, nameof(Users.User.Roles));
             await repository.LoadCollection(result, nameof(Users.User.Logins));
             return Ok(result);
@@ -47,44 +41,26 @@ namespace Brighid.Identity.Users
 
         [HttpPatch("{userId}/debug-mode", Name = "Users:SetDebugMode")]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
+        [ExceptionMapping<UserNotFoundException>(HttpStatusCode.NotFound)]
+        [ExceptionMapping<SecurityException>(HttpStatusCode.Forbidden)]
         public async Task<ActionResult> SetDebugMode(Guid userId, [FromBody] bool enabled)
         {
-            try
-            {
-                await service.SetDebugMode(userId, enabled, HttpContext.RequestAborted);
-                return NoContent();
-            }
-            catch (UserNotFoundException exception)
-            {
-                return NotFound(new { exception.Message });
-            }
+            await service.SetDebugMode(HttpContext.User, userId, enabled, HttpContext.RequestAborted);
+            return NoContent();
         }
 
         [HttpPost("{userId}/logins", Name = "Users:CreateLogin")]
         [Policies(new[] { nameof(IdentityPolicy.RestrictedToSelfByUserId) })]
+        [ExceptionMapping<UserNotFoundException>(HttpStatusCode.NotFound)]
+        [ExceptionMapping<UserLoginAlreadyExistsException>(HttpStatusCode.Conflict)]
+        [ExceptionMapping<ModelStateException>(HttpStatusCode.BadRequest)]
         public async Task<ActionResult<UserLogin>> CreateLogin(Guid userId, [FromBody] CreateUserLoginRequest loginInfo)
         {
-            try
-            {
-                ModelState.Remove(nameof(UserLogin.User));
-                ThrowIfModelStateIsInvalid();
+            ModelState.Remove(nameof(UserLogin.User));
+            ThrowIfModelStateIsInvalid();
 
-                var result = await service.CreateLogin(userId, loginInfo);
-                return Ok(result);
-            }
-            catch (UserNotFoundException e)
-            {
-                return NotFound(new { e.Message });
-            }
-            catch (UserLoginAlreadyExistsException e)
-            {
-                return Conflict(new { e.Message });
-            }
-            catch (ModelStateException e)
-            {
-#pragma warning disable IDE0037
-                return BadRequest(new { e.Message, Errors = e.Errors });
-            }
+            var result = await service.CreateLogin(userId, loginInfo, HttpContext.RequestAborted);
+            return Ok(result);
         }
 
         private void ThrowIfModelStateIsInvalid()

--- a/src/Server/Users/Exceptions/InvalidPrincipalException.cs
+++ b/src/Server/Users/Exceptions/InvalidPrincipalException.cs
@@ -1,0 +1,14 @@
+using System;
+
+#pragma warning disable CA1032
+
+namespace Brighid.Identity.Users
+{
+    public class InvalidPrincipalException : Exception
+    {
+        public InvalidPrincipalException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Server/Users/Exceptions/UserLoginNotFoundException.cs
+++ b/src/Server/Users/Exceptions/UserLoginNotFoundException.cs
@@ -1,0 +1,20 @@
+using System;
+
+#pragma warning disable CA1032
+
+namespace Brighid.Identity.Users
+{
+    public class UserLoginNotFoundException : Exception
+    {
+        public UserLoginNotFoundException(string loginProvider, string providerKey)
+            : base($"User Login for {loginProvider} with ID {providerKey} was not found.")
+        {
+            LoginProvider = loginProvider;
+            ProviderKey = providerKey;
+        }
+
+        public string LoginProvider { get; init; }
+
+        public string ProviderKey { get; init; }
+    }
+}

--- a/src/Server/Users/Extensions/UsersServiceCollectionExtensions.cs
+++ b/src/Server/Users/Extensions/UsersServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IUserService, DefaultUserService>();
             services.AddScoped<IUserRepository, DefaultUserRepository>();
             services.AddScoped<IUserLoginRepository, DefaultUserLoginRepository>();
+            services.AddScoped<IPrincipalService, DefaultPrincipalService>();
         }
     }
 }

--- a/src/Server/Users/Repositories/DefaultUserLoginRepository.cs
+++ b/src/Server/Users/Repositories/DefaultUserLoginRepository.cs
@@ -1,12 +1,32 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
 
 namespace Brighid.Identity.Users
 {
     public class DefaultUserLoginRepository : Repository<UserLogin, Guid>, IUserLoginRepository
     {
+        private static readonly Func<DatabaseContext, string, string, IAsyncEnumerable<UserLogin?>> FindByProviderNameAndKeyQuery = EF.CompileAsyncQuery<DatabaseContext, string, string, UserLogin?>(
+            (context, loginProvider, providerKey) =>
+                from login in context.Set<UserLogin>()
+                where login.LoginProvider == loginProvider && login.ProviderKey == providerKey
+                select login
+        );
+
         public DefaultUserLoginRepository(DatabaseContext context)
             : base(context)
         {
+        }
+
+        /// <inheritdoc />
+        public async Task<UserLogin?> FindByProviderNameAndKey(string loginProvider, string providerKey, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await FindByProviderNameAndKeyQuery(Context, loginProvider, providerKey).FirstOrDefaultAsync(cancellationToken);
         }
     }
 }

--- a/src/Server/Users/Repositories/IUserLoginRepository.cs
+++ b/src/Server/Users/Repositories/IUserLoginRepository.cs
@@ -1,8 +1,18 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Brighid.Identity.Users
 {
     public interface IUserLoginRepository : IRepository<UserLogin, Guid>
     {
+        /// <summary>
+        /// Finds a user login based on provider name and key.
+        /// </summary>
+        /// <param name="loginProvider">The name of the login provider that the user login is for (ie discord/google/etc).</param>
+        /// <param name="providerKey">The ID of the user within the login provider's system (ie the discord user id).</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting task.</returns>
+        Task<UserLogin?> FindByProviderNameAndKey(string loginProvider, string providerKey, CancellationToken cancellationToken);
     }
 }

--- a/src/Server/Users/Repositories/IUserRepository.cs
+++ b/src/Server/Users/Repositories/IUserRepository.cs
@@ -9,7 +9,7 @@ namespace Brighid.Identity.Users
 {
     public interface IUserRepository : IRepository<User, Guid>
     {
-        Task<User?> FindByLogin(string loginProvider, string providerKey, params string[] embeds);
+        Task<User?> FindByLogin(string loginProvider, string providerKey, CancellationToken cancellationToken = default);
 
         Task<IEnumerable<Role>?> FindRolesById(Guid id, CancellationToken cancellationToken = default);
     }

--- a/src/Server/Users/Services/DefaultPrincipalService.cs
+++ b/src/Server/Users/Services/DefaultPrincipalService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Security.Claims;
+
+using OpenIddict.Abstractions;
+
+namespace Brighid.Identity.Users
+{
+    /// <inheritdoc />
+    public class DefaultPrincipalService : IPrincipalService
+    {
+        /// <inheritdoc />
+        public Guid GetId(ClaimsPrincipal principal)
+        {
+            var sub = principal.GetClaim("sub") ?? throw new InvalidPrincipalException("The given principal did not have a sub claim.");
+            return Guid.TryParse(sub, out var id)
+                ? id
+                : throw new InvalidPrincipalException("The given principal had an invalid ID.");
+        }
+    }
+}

--- a/src/Server/Users/Services/IPrincipalService.cs
+++ b/src/Server/Users/Services/IPrincipalService.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Security.Claims;
+
+namespace Brighid.Identity.Users
+{
+    /// <summary>
+    /// Service for working with Principals.
+    /// </summary>
+    public interface IPrincipalService
+    {
+        /// <summary>
+        /// Gets the user id from the given principal.
+        /// </summary>
+        /// <param name="principal">The principal to get their id for.</param>
+        /// <returns>The principal's ID.</returns>
+        Guid GetId(ClaimsPrincipal principal);
+    }
+}

--- a/src/Server/Users/Services/IUserService.cs
+++ b/src/Server/Users/Services/IUserService.cs
@@ -1,22 +1,62 @@
 using System;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Brighid.Identity.Users
 {
+    /// <summary>
+    /// Service for interacting with and manipulating users within the Brighid Identity system.
+    /// </summary>
     public interface IUserService
     {
-        Task<User> Create(string username, string password, string? role = null);
+        /// <summary>
+        /// Creates a new user.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="password">The password the user uses to login.</param>
+        /// <param name="role">An optional role to place the user in.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting user.</returns>
+        Task<User> Create(string username, string password, string? role = null, CancellationToken cancellationToken = default);
 
-        Task<UserLogin> CreateLogin(Guid id, UserLogin loginInfo);
+        /// <summary>
+        /// Gets a user login by the provider name and key.  This will throw an exception if the login is not found, or if the login is disabled.
+        /// </summary>
+        /// <param name="loginProvider">The name of the login provider that the user login is for (ie discord/google/etc).</param>
+        /// <param name="providerKey">The ID of the user within the login provider's system (ie the discord user id).</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The requested user login.</returns>
+        Task<User> GetByLoginProviderKey(string loginProvider, string providerKey, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Creates a new user login for a given user.
+        /// </summary>
+        /// <param name="id">The id of the user to create a login for.</param>
+        /// <param name="loginInfo">Info about the user login to create.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting user login.</returns>
+        Task<UserLogin> CreateLogin(Guid id, UserLogin loginInfo, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Disables a user login based on the login provider and provider key.
+        /// </summary>
+        /// <param name="principal">The user requesting the operation.</param>
+        /// <param name="loginProvider">The name of the login provider that the user login is for (ie discord/google/etc).</param>
+        /// <param name="providerKey">The ID of the user within the login provider's system (ie the discord user id).</param>
+        /// <param name="enabled">Whether or not the login should be enabled.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting task.</returns>
+        Task SetLoginStatus(ClaimsPrincipal principal, string loginProvider, string providerKey, bool enabled, CancellationToken cancellationToken);
 
         /// <summary>
         /// Enables debug mode for the user with the given <paramref name="userId" />.
         /// </summary>
+        /// <param name="principal">The user requesting the operation.</param>
         /// <param name="userId">The ID of the user to enable debug mode for.</param>
         /// <param name="enabled">Value indicating whether or not debug mode should be enabled for a user.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        Task SetDebugMode(Guid userId, bool enabled, CancellationToken cancellationToken);
+        Task SetDebugMode(ClaimsPrincipal principal, Guid userId, bool enabled, CancellationToken cancellationToken);
     }
 }

--- a/tests/Internal/TestUtils.cs
+++ b/tests/Internal/TestUtils.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+using Brighid.Identity;
 
 using NSubstitute;
 
@@ -15,6 +18,13 @@ internal static class TestUtils
         }
 
         field.SetValue(target, value);
+    }
+
+    internal static IEnumerable<IExceptionMapping> GetExceptionMappings<T>(this T target, string method)
+    {
+        var type = target!.GetType();
+        var decl = type.GetMethod(method)!;
+        return from attr in decl.GetCustomAttributes() where attr is IExceptionMapping select (IExceptionMapping)attr;
     }
 
     internal static TArg GetArg<TArg>(object target, string methodName, int arg)

--- a/tests/Server/Users/Services/DefaultPrincipalServiceTests.cs
+++ b/tests/Server/Users/Services/DefaultPrincipalServiceTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Security.Claims;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using OpenIddict.Abstractions;
+
+namespace Brighid.Identity.Users
+{
+    public class DefaultPrincipalServiceTests
+    {
+        [TestFixture]
+        [Category("Unit")]
+        public class GetIdTests
+        {
+            [Test]
+            [Auto]
+            public void ShouldReturnTheParsedSubClaim(
+                Guid userId,
+                [Target] DefaultPrincipalService service
+            )
+            {
+                var principal = new ClaimsPrincipal();
+                principal.AddIdentity(new ClaimsIdentity());
+                principal.SetClaim("sub", userId.ToString());
+
+                var result = service.GetId(principal);
+
+                result.Should().Be(userId);
+            }
+
+            [Test]
+            [Auto]
+            public void ShouldThrowInvalidPrincipalExceptionIfTheSubClaimIsntPresent(
+                [Target] DefaultPrincipalService service
+            )
+            {
+                var principal = new ClaimsPrincipal();
+                principal.AddIdentity(new ClaimsIdentity());
+
+                Action func = () => service.GetId(principal);
+
+                func.Should().Throw<InvalidPrincipalException>();
+            }
+
+            [Test]
+            [Auto]
+            public void ShouldThrowInvalidPrincipalExceptionIfTheSubClaimIsNotAGuid(
+                [Target] DefaultPrincipalService service
+            )
+            {
+                var principal = new ClaimsPrincipal();
+                principal.AddIdentity(new ClaimsIdentity());
+                principal.SetClaim("sub", "notaguid");
+
+                Action func = () => service.GetId(principal);
+
+                func.Should().Throw<InvalidPrincipalException>();
+            }
+        }
+    }
+}

--- a/tests/Server/Users/Services/DefaultUserServiceTests.cs
+++ b/tests/Server/Users/Services/DefaultUserServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Reflection;
+using System.Security;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +16,7 @@ using Microsoft.EntityFrameworkCore;
 using MySqlConnector;
 
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 
 using NUnit.Framework;
 
@@ -67,6 +70,43 @@ namespace Brighid.Identity.Users
         }
 
         [Category("Unit")]
+        public class GetByLoginProviderKey
+        {
+            [Test]
+            [Auto]
+            public async Task ShouldReturnUserFromRepository(
+                string loginProvider,
+                string providerKey,
+                [Frozen] User user,
+                [Frozen] IUserRepository repository,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                var result = await service.GetByLoginProviderKey(loginProvider, providerKey, cancellationToken);
+
+                result.Should().Be(user);
+
+                await repository.Received().FindByLogin(Is(loginProvider), Is(providerKey), Is(cancellationToken));
+            }
+
+            [Test]
+            [Auto]
+            public async Task ShouldThrowIfNoMatchingUserInTheRepository(
+                string loginProvider,
+                string providerKey,
+                [Frozen] IUserRepository repository,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                repository.FindByLogin(Any<string>(), Any<string>(), Any<CancellationToken>()).ReturnsNull();
+                Func<Task> func = () => service.GetByLoginProviderKey(loginProvider, providerKey, cancellationToken);
+                await func.Should().ThrowAsync<UserLoginNotFoundException>();
+            }
+        }
+
+        [Category("Unit")]
         public class CreateLogin
         {
             [Test]
@@ -75,12 +115,13 @@ namespace Brighid.Identity.Users
                 Guid userId,
                 UserLogin loginInfo,
                 [Frozen, Substitute] UserManager<User> userManager,
-                [Target] DefaultUserService service
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
             )
             {
                 userManager.FindByIdAsync(Any<string>()).Returns((User)null!);
 
-                Func<Task> func = async () => await service.CreateLogin(userId, loginInfo);
+                Func<Task> func = async () => await service.CreateLogin(userId, loginInfo, cancellationToken);
 
                 await func.Should().ThrowAsync<UserNotFoundException>();
                 await userManager.Received().FindByIdAsync(Is(userId.ToString()));
@@ -94,7 +135,8 @@ namespace Brighid.Identity.Users
                 UserLogin loginInfo,
                 [Frozen, Substitute] IUserLoginRepository loginRepository,
                 [Frozen, Substitute] UserManager<User> userManager,
-                [Target] DefaultUserService service
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
             )
             {
                 var errorCode = MySqlErrorCode.DuplicateKeyEntry;
@@ -104,7 +146,7 @@ namespace Brighid.Identity.Users
                     throw new DbUpdateException(string.Empty, exception)
                 );
 
-                Func<Task> func = async () => await service.CreateLogin(userId, loginInfo);
+                Func<Task> func = async () => await service.CreateLogin(userId, loginInfo, cancellationToken);
 
                 await func.Should().ThrowAsync<UserLoginAlreadyExistsException>();
             }
@@ -117,12 +159,13 @@ namespace Brighid.Identity.Users
                 UserLogin loginInfo,
                 [Frozen, Substitute] IUserLoginRepository loginRepository,
                 [Frozen, Substitute] UserManager<User> userManager,
-                [Target] DefaultUserService service
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
             )
             {
                 userManager.FindByIdAsync(Any<string>()).Returns(user);
 
-                await service.CreateLogin(userId, loginInfo);
+                await service.CreateLogin(userId, loginInfo, cancellationToken);
 
                 await loginRepository.Received().Add(Is<UserLogin>(login =>
                     login.Id == loginInfo.Id &&
@@ -137,14 +180,102 @@ namespace Brighid.Identity.Users
                 User user,
                 UserLogin loginInfo,
                 [Frozen, Substitute] UserManager<User> userManager,
-                [Target] DefaultUserService service
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
             )
             {
                 userManager.FindByIdAsync(Any<string>()).Returns(user);
 
-                var result = await service.CreateLogin(userId, loginInfo);
+                var result = await service.CreateLogin(userId, loginInfo, cancellationToken);
 
                 result.Should().Be(loginInfo);
+            }
+        }
+
+        [Category("Unit")]
+        public class SetLoginStatus
+        {
+            [Test]
+            [Auto]
+            public async Task ShouldSearchRepositoryForUserLogin(
+                ClaimsPrincipal principal,
+                string loginProvider,
+                string providerKey,
+                bool enabled,
+                [Frozen] UserLogin userLogin,
+                [Frozen] IUserLoginRepository repository,
+                [Frozen] IPrincipalService principalService,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userLogin.UserId);
+
+                await service.SetLoginStatus(principal, loginProvider, providerKey, enabled, cancellationToken);
+
+                await repository.Received().FindByProviderNameAndKey(loginProvider, providerKey, cancellationToken);
+            }
+
+            [Test]
+            [Auto]
+            public async Task ShouldThrowIfLoginWasNotFound(
+                ClaimsPrincipal principal,
+                string loginProvider,
+                string providerKey,
+                bool enabled,
+                [Frozen] UserLogin userLogin,
+                [Frozen] IPrincipalService principalService,
+                [Frozen] IUserLoginRepository repository,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userLogin.UserId);
+                repository.FindByProviderNameAndKey(Any<string>(), Any<string>(), Any<CancellationToken>()).ReturnsNull();
+
+                Func<Task> func = () => service.SetLoginStatus(principal, loginProvider, providerKey, enabled, cancellationToken);
+
+                var result = (await func.Should().ThrowAsync<UserLoginNotFoundException>()).Which;
+                result.LoginProvider.Should().Be(loginProvider);
+                result.ProviderKey.Should().Be(providerKey);
+            }
+
+            [Test]
+            [Auto]
+            public async Task ShouldThrowIfLoginProviderDoesNotBelongToTheUser(
+                ClaimsPrincipal principal,
+                string loginProvider,
+                string providerKey,
+                bool enabled,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                Func<Task> func = () => service.SetLoginStatus(principal, loginProvider, providerKey, enabled, cancellationToken);
+
+                await func.Should().ThrowAsync<SecurityException>();
+            }
+
+            [Test]
+            [Auto]
+            public async Task ShouldDisableTheUserLogin(
+                ClaimsPrincipal principal,
+                string loginProvider,
+                string providerKey,
+                bool enabled,
+                [Frozen] UserLogin userLogin,
+                [Frozen] IPrincipalService principalService,
+                [Frozen] IUserLoginRepository repository,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                userLogin.Enabled = !enabled;
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userLogin.UserId);
+                await service.SetLoginStatus(principal, loginProvider, providerKey, enabled, cancellationToken);
+
+                await repository.Received().Save(Is(userLogin), Is(cancellationToken));
+                userLogin.Enabled.Should().Be(enabled);
             }
         }
 
@@ -155,15 +286,18 @@ namespace Brighid.Identity.Users
             [Auto]
             public async Task ShouldTurnOnDebugModeForUsersThatExist(
                 Guid userId,
+                ClaimsPrincipal principal,
                 [Frozen] User user,
+                [Frozen] IPrincipalService principalService,
                 [Frozen] IUserRepository repository,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userId);
                 user.Flags = UserFlags.None;
 
-                await service.SetDebugMode(userId, true, cancellationToken);
+                await service.SetDebugMode(principal, userId, true, cancellationToken);
 
                 await repository.Received().Save(Is<User>(user => user.Flags.HasFlag(UserFlags.Debug)), Is(cancellationToken));
             }
@@ -172,31 +306,54 @@ namespace Brighid.Identity.Users
             [Auto]
             public async Task ShouldTurnOffDebugModeForUsersThatExist(
                 Guid userId,
+                ClaimsPrincipal principal,
                 [Frozen] User user,
+                [Frozen] IPrincipalService principalService,
                 [Frozen] IUserRepository repository,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userId);
                 user.Flags = UserFlags.Debug;
 
-                await service.SetDebugMode(userId, false, cancellationToken);
+                await service.SetDebugMode(principal, userId, false, cancellationToken);
 
                 await repository.Received().Save(Is<User>(user => !user.Flags.HasFlag(UserFlags.Debug)), Is(cancellationToken));
             }
 
             [Test]
             [Auto]
+            public async Task ShouldThrowSecurityExceptionIfIdDoesNotMatchPrincipal(
+                Guid userId,
+                ClaimsPrincipal principal,
+                [Frozen] User user,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                user.Flags = UserFlags.Debug;
+
+                Func<Task> func = () => service.SetDebugMode(principal, userId, false, cancellationToken);
+
+                await func.Should().ThrowAsync<SecurityException>();
+            }
+
+            [Test]
+            [Auto]
             public async Task ShouldThrowIfUserNotFound(
                 Guid userId,
+                ClaimsPrincipal principal,
+                [Frozen] IPrincipalService principalService,
                 [Frozen] IUserRepository repository,
                 [Target] DefaultUserService service,
                 CancellationToken cancellationToken
             )
             {
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userId);
                 repository.FindById(Any<Guid>(), Any<CancellationToken>()).Returns(null as User);
 
-                Func<Task> func = () => service.SetDebugMode(userId, true, cancellationToken);
+                Func<Task> func = () => service.SetDebugMode(principal, userId, true, cancellationToken);
 
                 await func.Should().ThrowAsync<UserNotFoundException>();
             }


### PR DESCRIPTION
Adds an endpoint for disabling user logins.   Once a user login is disabled, it cannot be fetched individually from the API's LoginProviders:GetUserByLoginProviderKey endpoint.

- Fixes an issue with user flag serialization / deserialization
- Fixes an issue where the set debug mode endpoint was not ensuring the requestor can only change their own debug mode setting.