### PR TITLE
BRGD-253 Expire Cache on Login State Changes

### DIFF
--- a/src/Server/Users/Services/DefaultUserService.cs
+++ b/src/Server/Users/Services/DefaultUserService.cs
@@ -104,6 +104,7 @@ namespace Brighid.Identity.Users
 
             login.Enabled = enabled;
             await loginRepository.Save(login, cancellationToken);
+            await cacheService.ClearExternalUserCache(login.UserId, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/tests/Server/Users/Services/DefaultUserServiceTests.cs
+++ b/tests/Server/Users/Services/DefaultUserServiceTests.cs
@@ -277,6 +277,27 @@ namespace Brighid.Identity.Users
                 await repository.Received().Save(Is(userLogin), Is(cancellationToken));
                 userLogin.Enabled.Should().Be(enabled);
             }
+
+            [Test]
+            [Auto]
+            public async Task ShouldClearExternalUserCache(
+                ClaimsPrincipal principal,
+                string loginProvider,
+                string providerKey,
+                bool enabled,
+                [Frozen] UserLogin userLogin,
+                [Frozen] IPrincipalService principalService,
+                [Frozen] IUserCacheService cacheService,
+                [Target] DefaultUserService service,
+                CancellationToken cancellationToken
+            )
+            {
+                userLogin.Enabled = !enabled;
+                principalService.GetId(Any<ClaimsPrincipal>()).Returns(userLogin.UserId);
+                await service.SetLoginStatus(principal, loginProvider, providerKey, enabled, cancellationToken);
+
+                await cacheService.Received().ClearExternalUserCache(Is(userLogin.UserId), Is(cancellationToken));
+            }
         }
 
         [Category("Unit")]


### PR DESCRIPTION
Expires external user caches whenever a login enabled state changes.